### PR TITLE
ASCII PLY is not supported, error out

### DIFF
--- a/raylib/rayply.cpp
+++ b/raylib/rayply.cpp
@@ -348,6 +348,13 @@ bool readPly(const std::string &file_name, bool is_ray_cloud,
     {
       break;
     }
+
+    if (line.find("format ascii 1.0") != std::string::npos)
+    {
+      std::cerr << "ASCII PLY not supported " << file_name << std::endl;
+      return false;
+    }
+
     // support multiple data types
     DataType data_type = kDTnone;
     if (line.find("property float") != std::string::npos)


### PR DESCRIPTION
The PLY implementation is using `istream::read` which is for binary PLY only.
Better for raycloudtools to error-out more clearly, than warn about unexpected values.