### PR TITLE
Cmake and Docker Improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ if(WITH_LAS)
   list(APPEND RAYTOOLS_INCLUDE ${libLAS_INCLUDE_DIRS})
   list(APPEND RAYTOOLS_LINK ${libLAS_LIBRARIES})
 endif(WITH_LAS)
+
 if(WITH_QHULL)
   # Find the qhull that provides a config with targets first
   find_package(Qhull CONFIG QUIET)
@@ -73,18 +74,36 @@ if(WITH_QHULL)
   list(APPEND RAYTOOLS_INCLUDE ${QHULL_INCLUDE_DIRS})
   list(APPEND RAYTOOLS_LINK ${QHULL_LIBRARIES})
 endif(WITH_QHULL)
-if(WITH_TIFF)
-  find_package(GeoTIFF REQUIRED)
-  find_package(PROJ REQUIRED COMPONENTS proj)
-  list(APPEND RAYTOOLS_INCLUDE ${GEOTIFF_INCLUDE_DIR})
-  list(APPEND RAYTOOLS_LINK ${GEOTIFF_LIBRARIES})
-  find_package(TIFF REQUIRED)
-  list(APPEND RAYTOOLS_INCLUDE ${TIFF_INCLUDE_DIRS})
-  list(APPEND RAYTOOLS_LINK ${TIFF_LIBRARIES})
-  find_package(PROJ REQUIRED CONFIG)
-  list(APPEND RAYTOOLS_INCLUDE ${PROJ_INCLUDE_DIR})
-  list(APPEND RAYTOOLS_LINK ${PROJ_LIBRARIES})
-endif(WITH_TIFF)
+
+if (WITH_TIFF)
+    # Find and configure GeoTIFF
+    find_package(GeoTIFF REQUIRED)
+  
+    if(GeoTIFF_FOUND)
+      list(APPEND RAYTOOLS_INCLUDE ${GeoTIFF_INCLUDE_DIR})
+      list(APPEND RAYTOOLS_LINK ${GeoTIFF_LIBRARIES})
+    else()
+      message(FATAL_ERROR "GeoTIFF library not found.")
+    endif()
+
+    # Find and configure TIFF
+    find_package(TIFF REQUIRED)
+    if (TIFF_FOUND)
+        list(APPEND RAYTOOLS_INCLUDE ${TIFF_INCLUDE_DIRS})
+        list(APPEND RAYTOOLS_LINK ${TIFF_LIBRARIES})
+    else()
+        message(FATAL_ERROR "TIFF library not found.")
+    endif()
+
+    # Find and configure PROJ
+    find_package(PROJ REQUIRED)
+    if (PROJ_FOUND)
+        list(APPEND RAYTOOLS_INCLUDE ${PROJ_INCLUDE_DIRS})
+        list(APPEND RAYTOOLS_LINK ${PROJ_LIBRARIES})
+    else()
+        message(FATAL_ERROR "PROJ library not found.")
+    endif()
+endif (WITH_TIFF)
 
 if(WITH_TBB)
 # Helper macro to Find TBB prefering TBBConfig, falling back to FindTBB. TBB_LIBRARIES will be defined in both cases.

--- a/cmake/FindGeoTIFF.cmake
+++ b/cmake/FindGeoTIFF.cmake
@@ -1,0 +1,29 @@
+# FindGeoTIFF.cmake
+
+# Try to find the GeoTIFF library and headers
+find_path(GeoTIFF_INCLUDE_DIR NAMES geotiff.h
+    HINTS
+    ${CMAKE_INSTALL_PREFIX}/include
+    /usr/local/include/geotiff
+    /usr/include
+)
+
+find_library(GeoTIFF_LIBRARY NAMES geotiff
+    HINTS
+    ${CMAKE_INSTALL_PREFIX}/lib
+    /usr/local/lib
+    /usr/lib
+    /usr/lib/x86_64-linux-gnu
+)
+
+# Handle the result
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(GeoTIFF REQUIRED_VARS GeoTIFF_INCLUDE_DIR GeoTIFF_LIBRARY)
+
+if(GeoTIFF_FOUND)
+    set(GeoTIFF_LIBRARIES ${GeoTIFF_LIBRARY})
+else()
+    set(GeoTIFF_LIBRARIES "")
+endif()
+
+mark_as_advanced(GeoTIFF_INCLUDE_DIR GeoTIFF_LIBRARY)

--- a/cmake/FindPROJ.cmake
+++ b/cmake/FindPROJ.cmake
@@ -1,0 +1,41 @@
+# FindPROJ.cmake
+
+if (PROJ_FOUND)
+    # PROJ is already found, no need to search again
+    return()
+endif()
+
+# Find the PROJ library
+find_package_handle_standard_args(PROJ DEFAULT_MSG PROJ_LIBRARY PROJ_INCLUDE_DIR)
+
+# Define the PROJ library
+find_library(PROJ_LIBRARY
+    NAMES proj
+    PATHS ${CMAKE_LIBRARY_PATH}
+    NO_DEFAULT_PATH
+)
+
+# Define the PROJ include directory
+find_path(PROJ_INCLUDE_DIR
+    NAMES proj.h
+    PATHS ${CMAKE_INCLUDE_PATH}
+    NO_DEFAULT_PATH
+)
+
+# Handle the results
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(PROJ
+    REQUIRED_VARS PROJ_LIBRARY PROJ_INCLUDE_DIR
+    VERSION_VAR PROJ_VERSION
+)
+
+# Provide variables for the library and include directory
+set(PROJ_INCLUDE_DIRS ${PROJ_INCLUDE_DIR})
+set(PROJ_LIBRARIES ${PROJ_LIBRARY})
+
+# Provide version information if available
+if (PROJ_VERSION)
+    set(PROJ_VERSION_STRING "${PROJ_VERSION}")
+else()
+    set(PROJ_VERSION_STRING "unknown")
+endif()

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,14 +41,14 @@ RUN cd /home && \
     git clone https://github.com/csiro-robotics/raycloudtools.git && \
     cd raycloudtools && \
     mkdir build && cd build && \
-    cmake .. -DGEOTIFF_LIBRARIES=/usr/lib/libgeotiff.so -DWITH_QHULL=ON -DWITH_LAS=ON -DWITH_TIFF=ON -DDOUBLE_RAYS=ON -DRAYCLOUD_BUILD_TESTS=ON && \
-    make -j$(nproc) && make install 
+    cmake .. -DGEOTIFF_LIBRARIES=/usr/lib/libgeotiff.so -DWITH_QHULL=ON -DWITH_LAS=ON -DWITH_TIFF=ON -DDOUBLE_RAYS=ON -DRAYCLOUD_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Release && \
+    make -j$(nproc) && make install
         
 RUN cd /home && \
     git clone https://github.com/csiro-robotics/treetools.git && \
     cd treetools && \
     mkdir build && cd build && \
-    cmake .. -DWITH_TIFF=ON && \
+    cmake .. -DWITH_TIFF=ON -DCMAKE_BUILD_TYPE=Release && \
     make -j$(nproc) && make install
 
 WORKDIR /data

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,7 +41,7 @@ RUN cd /home && \
     git clone https://github.com/csiro-robotics/raycloudtools.git && \
     cd raycloudtools && \
     mkdir build && cd build && \
-    cmake .. -DGEOTIFF_LIBRARIES=/usr/lib/libgeotiff.so -DWITH_QHULL=ON -DWITH_LAS=ON -DWITH_TIFF=ON -DRAYCLOUD_BUILD_TESTS=ON && \
+    cmake .. -DGEOTIFF_LIBRARIES=/usr/lib/libgeotiff.so -DWITH_QHULL=ON -DWITH_LAS=ON -DWITH_TIFF=ON -DDOUBLE_RAYS=ON -DRAYCLOUD_BUILD_TESTS=ON && \
     make -j$(nproc) && make install 
         
 RUN cd /home && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,54 +1,60 @@
-FROM alpine:3
+FROM frolvlad/alpine-glibc:alpine-3
 
-RUN apk update
+RUN apk update && apk add --no-cache make cmake g++ git proj-dev eigen-dev boost-dev libgeotiff-dev gtest-dev wget
 
-RUN apk add make cmake g++ git proj-dev eigen-dev boost-dev libgeotiff-dev gtest-dev && \
-    cd /usr/share/cmake/Modules && \
+# Adding FindGeoTIFF.cmake
+RUN cd /usr/share/cmake/Modules && \
     wget https://raw.githubusercontent.com/ufz/geotiff/master/cmake/FindGeoTIFF.cmake
 
+# Building libnabo
 RUN cd /home && \
     git clone https://github.com/ethz-asl/libnabo.git && \
     cd libnabo && \
     git checkout tags/1.0.7 && \
     mkdir build && cd build && \
-    cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo && \
+    cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-O3" && \
     make -j$(nproc) && make install
 
+# Building LASzip
 RUN cd /home && \
     git clone https://github.com/LASzip/LASzip.git && \
     cd LASzip && \
     git checkout tags/2.0.1 && \
-    mkdir build && cd build && \ 
-    cmake .. && \
+    mkdir build && cd build && \
+    cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-O3" && \
     make -j$(nproc) && make install
 
+# Building libLAS
 RUN cd /home && \
     git clone https://github.com/libLAS/libLAS.git && \
-    cd libLAS && \ 
+    cd libLAS && \
     mkdir build && cd build && \
-    cmake .. -DWITH_LASZIP=ON -DWITH_GEOTIFF=OFF -DCMAKE_CXX_STANDARD=11 && \
+    cmake .. -DWITH_LASZIP=ON -DWITH_GEOTIFF=OFF -DCMAKE_CXX_STANDARD=11 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-O3" && \
     make -j$(nproc) && make install
 
+# Building Qhull
 RUN cd /home && \
     git clone http://github.com/qhull/qhull.git && \
     cd qhull && \
     git checkout tags/v7.3.2 && \
     mkdir -p build && cd build && \
-    cmake .. -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=true && \
+    cmake .. -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=true -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-O3" && \
     make -j$(nproc) && make install
 
+# Building raycloudtools
 RUN cd /home && \
     git clone https://github.com/csiro-robotics/raycloudtools.git && \
     cd raycloudtools && \
     mkdir build && cd build && \
-    cmake .. -DGEOTIFF_LIBRARIES=/usr/lib/libgeotiff.so -DWITH_QHULL=ON -DWITH_LAS=ON -DWITH_TIFF=ON -DDOUBLE_RAYS=ON -DRAYCLOUD_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Release && \
+    cmake .. -DGEOTIFF_LIBRARIES=/usr/lib/libgeotiff.so -DWITH_QHULL=ON -DWITH_LAS=ON -DWITH_TIFF=ON -DRAYCLOUD_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-O3" && \
     make -j$(nproc) && make install
-        
+
+# Building treetools
 RUN cd /home && \
     git clone https://github.com/csiro-robotics/treetools.git && \
     cd treetools && \
     mkdir build && cd build && \
-    cmake .. -DWITH_TIFF=ON -DCMAKE_BUILD_TYPE=Release && \
+    cmake .. -DWITH_TIFF=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-O3" && \
     make -j$(nproc) && make install
 
 WORKDIR /data

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,14 +12,12 @@ RUN apt-get update && apt-get upgrade -y && \
     apt-get install -y \
     git \
     build-essential \
-    gdb \
     cmake \
-    cmake-curses-gui \
     clang-tidy \
     libeigen3-dev \
     libproj-dev \
     libgeotiff-dev \
-    libboost-all-dev \
+    libboost-all-dev && \
     rm -rf /var/lib/apt/lists/*
     
 # Create a directory for building packages

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,60 +1,115 @@
-FROM frolvlad/alpine-glibc:alpine-3
+FROM ubuntu:22.04
 
-RUN apk update && apk add --no-cache make cmake g++ git proj-dev eigen-dev boost-dev libgeotiff-dev gtest-dev wget
+# Avoid prompts from apt
+ENV DEBIAN_FRONTEND=noninteractive
 
-# Adding FindGeoTIFF.cmake
-RUN cd /usr/share/cmake/Modules && \
-    wget https://raw.githubusercontent.com/ufz/geotiff/master/cmake/FindGeoTIFF.cmake
+# Set LC_ALL and unset LANGUAGE
+ENV LC_ALL=C
+ENV LANGUAGE=
 
-# Building libnabo
-RUN cd /home && \
-    git clone https://github.com/ethz-asl/libnabo.git && \
-    cd libnabo && \
-    git checkout tags/1.0.7 && \
-    mkdir build && cd build && \
-    cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-O3" && \
-    make -j$(nproc) && make install
+# Update, install dependencies and cleanup
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get install -y \
+    git \
+    build-essential \
+    gdb \
+    cmake \
+    cmake-curses-gui \
+    clang-tidy \
+    libeigen3-dev \
+    libproj-dev \
+    libgeotiff-dev \
+    libboost-all-dev \
+    rm -rf /var/lib/apt/lists/*
+    
+# Create a directory for building packages
+RUN mkdir -p /build && \
+    cd /build
 
-# Building LASzip
-RUN cd /home && \
-    git clone https://github.com/LASzip/LASzip.git && \
+# Clone, build and clean up LASzip
+RUN git clone https://github.com/LASzip/LASzip.git && \
     cd LASzip && \
     git checkout tags/2.0.1 && \
     mkdir build && cd build && \
-    cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-O3" && \
-    make -j$(nproc) && make install
+    cmake .. && \
+    make -j$(nproc) && \
+    make install && \
+    cp bin/Release/liblas* /usr/lib/ && \
+    cd ../.. && rm -rf LASzip
 
-# Building libLAS
-RUN cd /home && \
-    git clone https://github.com/libLAS/libLAS.git && \
+# Clone, build and clean up libLAS
+RUN git clone https://github.com/libLAS/libLAS.git && \
     cd libLAS && \
     mkdir build && cd build && \
-    cmake .. -DWITH_LASZIP=ON -DWITH_GEOTIFF=OFF -DCMAKE_CXX_STANDARD=11 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-O3" && \
-    make -j$(nproc) && make install
+    cmake .. -DWITH_LASZIP=ON -DWITH_GEOTIFF=OFF -DCMAKE_CXX_STANDARD=11 && \
+    make -j$(nproc) && \
+    make install && \
+    cd ../.. && rm -rf libLAS
 
-# Building Qhull
-RUN cd /home && \
-    git clone http://github.com/qhull/qhull.git && \
+# Clone, build and clean up Qhull
+RUN git clone https://github.com/qhull/qhull.git && \
     cd qhull && \
     git checkout tags/v7.3.2 && \
-    mkdir -p build && cd build && \
-    cmake .. -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=true -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-O3" && \
-    make -j$(nproc) && make install
+    cd build && \
+    cmake .. -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=true && \
+    make -j$(nproc) && \
+    make install && \
+    cd ../.. && rm -rf qhull
 
-# Building raycloudtools
-RUN cd /home && \
-    git clone https://github.com/csiro-robotics/raycloudtools.git && \
+# Clone, build and clean up libnabo
+RUN git clone https://github.com/ethz-asl/libnabo.git && \
+    cd libnabo && \
+    git checkout tags/1.0.7 && \
+    mkdir build && cd build && \
+    cmake .. -DCMAKE_BUILD_TYPE=Release && \
+    make -j$(nproc) && \
+    make install && \
+    cd ../.. && rm -rf libnabo
+
+# Clone, build and install raycloudtools
+RUN git clone https://github.com/tim-devereux/raycloudtools.git && \
     cd raycloudtools && \
-    mkdir build && cd build && \
-    cmake .. -DGEOTIFF_LIBRARIES=/usr/lib/libgeotiff.so -DWITH_QHULL=ON -DWITH_LAS=ON -DWITH_TIFF=ON -DRAYCLOUD_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-O3" && \
-    make -j$(nproc) && make install
+    git checkout riegl && \
+    mkdir build && \
+    cd build && \
+    cmake .. \
+        -DGeoTIFF_INCLUDE_DIR=/usr/include/geotiff \
+        -DGeoTIFF_LIBRARY=/usr/lib/x86_64-linux-gnu/libgeotiff.so \
+        -DPROJ_INCLUDE_DIR=/usr/include/proj \
+        -DPROJ_LIBRARY=/usr/lib/x86_64-linux-gnu/libproj.so \
+        -DWITH_QHULL=ON \
+        -DWITH_LAS=ON \
+        -DDOUBLE_RAYS=ON \
+        -DWITH_TIFF=ON \
+        -DCMAKE_BUILD_TYPE=Release \
+    make -j$(nproc) && \
+    make install && \
+    cd ../.. && \
+    rm -rf raycloudtools
 
-# Building treetools
-RUN cd /home && \
-    git clone https://github.com/csiro-robotics/treetools.git && \
+# Clone and build TreeTools
+RUN git clone https://github.com/tim-devereux/treetools.git && \
     cd treetools && \
-    mkdir build && cd build && \
-    cmake .. -DWITH_TIFF=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-O3" && \
-    make -j$(nproc) && make install
+    mkdir -p build && \
+    cd build && \
+    cmake .. \
+        -DPROJ_INCLUDE_DIR=/usr/include/proj \
+        -DPROJ_LIBRARY=/usr/lib/x86_64-linux-gnu/libproj.so \
+        -DWITH_TIFF=ON \
+        -DCMAKE_BUILD_TYPE=Release && \
+    make -j$(nproc) && \
+    make install && \
+    cd ../.. && \
+    rm -rf treetools
+    
+# Update ldconfig
+RUN ldconfig /usr/local/lib
 
-WORKDIR /data
+# Clean up build directory
+RUN rm -rf /build
+
+# Set the working directory
+WORKDIR /workspace
+
+# Set the entrypoint
+ENTRYPOINT ["/bin/bash"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -67,7 +67,6 @@ RUN git clone https://github.com/ethz-asl/libnabo.git && \
 # Clone, build and install raycloudtools
 RUN git clone https://github.com/tim-devereux/raycloudtools.git && \
     cd raycloudtools && \
-    git checkout riegl && \
     mkdir build && \
     cd build && \
     cmake .. \
@@ -79,7 +78,7 @@ RUN git clone https://github.com/tim-devereux/raycloudtools.git && \
         -DWITH_LAS=ON \
         -DDOUBLE_RAYS=ON \
         -DWITH_TIFF=ON \
-        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_BUILD_TYPE=Release && \
     make -j$(nproc) && \
     make install && \
     cd ../.. && \

--- a/docker/README.md
+++ b/docker/README.md
@@ -5,18 +5,18 @@
 #### date: June 24, 2023
 ---
 
-The provided docker file allows easy building from a lightweight linux image ([Alpine v3](https://hub.docker.com/_/alpine/)).
+The provided docker file allows easy building ([Ubuntu22.04](https://hub.docker.com/_/ubuntu/)).
 
 Be sure to have the latest [Docker](https://docs.docker.com/engine/install/) installed in your system. To build the raycloudtools image, run:
 
 ```
-docker build -f Dockerfile -t raytools .
+docker build -f Dockerfile -t raycloudtools .
 ```
 
-This image will download and compile raycloudtools and all its dependencies (including treetools, so you can process rayextract outputs). You can then run the `raytools` image as a standalone executable. The basic command is `docker run -v your/local/datadir:/data raytools` followed by the specific ray tool you want to use, as in: 
+This image will download and compile raycloudtools and all its dependencies (including treetools, so you can process rayextract outputs). You can then run the `raycloudtools` image as a standalone executable. The basic command is `docker run -v your/local/datadir:/data raycloudtools` followed by the specific tool you want to use, as in: 
 
 ```
-docker run -v your/local/datadir:/data raytools rayimport --help
+docker run -v your/local/datadir:/data raycloudtools rayimport
 ```
 
 Here's an example of a pipeline to process a forest plot:
@@ -28,7 +28,7 @@ cd mydata
 
 # [optional] create a local environment variable with the arguments you 
 # want to pass to docker - so you don't have to rewrite it everytime
-CMD="run --rm -u $(id -u $USER) -v $PWD:/data raytools"
+CMD="run --rm -u $(id -u $USER) -v $PWD:/data raycloudtools"
 
 # generate some sample data
 docker $CMD raycreate forest 3

--- a/docker/README.md
+++ b/docker/README.md
@@ -5,7 +5,7 @@
 #### date: June 24, 2023
 ---
 
-The provided docker file allows easy building ([Ubuntu22.04](https://hub.docker.com/_/ubuntu/)).
+The provided dockerfile allows easy building. It is based on [Ubuntu22.04](https://hub.docker.com/_/ubuntu/).
 
 Be sure to have the latest [Docker](https://docs.docker.com/engine/install/) installed in your system. To build the raycloudtools image, run:
 


### PR DESCRIPTION
Added better handling of geotiff and proj dependencies.

Added FindPROJ.cmake and FindGeoTIFF.cmake, which fixed issues finding these libs on Ubuntu. 

Changes to the dockerfile to fix performance issues from using Alpine Linux as the base image. Alpine uses musl as the C standard library, not glibc, and is significantly less performant (rayextract trees using Alpine could take 5 mins, Ubuntu 20 seconds) . Now it's using Ubtuntu 22.04. This is also more in line with the development environment. 

Updated Docker README to reflect changes. 