### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -108,5 +108,13 @@ RUN rm -rf /build
 # Set the working directory
 WORKDIR /workspace
 
-# Set the entrypoint
-ENTRYPOINT ["/bin/bash"]
+# Handle entrypoint for interactive and non-interactive
+RUN echo '#!/bin/bash\n\
+if [ $# -eq 0 ]; then\n\
+    exec /bin/bash\n\
+else\n\
+    exec "$@"\n\
+fi' > /entrypoint.sh && chmod +x /entrypoint.sh
+
+# Set the entrypoint to script
+ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Handle container entrypoint for interactive and non-interactive usage. 

If no arguments are passed to the container, it starts a bash shell. If arguments are passed, it executes them as a command. Tested on Windows and Fedora Linux.