### PR TITLE
Option to crop interest zone and filter min dbh trees

### DIFF
--- a/raycloudtools/rayextract/rayextract.cpp
+++ b/raycloudtools/rayextract/rayextract.cpp
@@ -1,3 +1,4 @@
+
 // Copyright (c) 2020
 // Commonwealth Scientific and Industrial Research Organisation (CSIRO)
 // ABN 41 687 119 230
@@ -5,10 +6,10 @@
 // Author: Thomas Lowe
 #include "raylib/extraction/rayclusters.h"
 #include "raylib/extraction/rayforest.h"
+#include "raylib/extraction/rayleaves.h"
 #include "raylib/extraction/rayterrain.h"
 #include "raylib/extraction/raytrees.h"
 #include "raylib/extraction/raytrunks.h"
-#include "raylib/extraction/rayleaves.h"
 #include "raylib/raycloud.h"
 #include "raylib/rayforestgen.h"
 #include "raylib/rayforeststructure.h"
@@ -25,7 +26,8 @@ static std::string extract_type;
 
 void usage(int exit_code = 1)
 {
-  const bool none = extract_type != "terrain" && extract_type != "trunks" && extract_type != "forest" && extract_type != "trees" && extract_type != "leaves";
+  const bool none = extract_type != "terrain" && extract_type != "trunks" && extract_type != "forest" &&
+                    extract_type != "trees" && extract_type != "leaves";
   // clang-format off
   std::cout << "Extract natural features into a text file or mesh file" << std::endl;
   std::cout << "usage:" << std::endl;
@@ -55,12 +57,14 @@ void usage(int exit_code = 1)
     std::cout << "                            --crop_length 1.0    - (-p) crops small branches to this distance from end" << std::endl;
     std::cout << "                            --distance_limit 1   - (-d) maximum distance between neighbour points in a tree" << std::endl;
     std::cout << "                            --height_min 2       - (-h) minimum height counted as a tree" << std::endl;
+    std::cout << "                            --min_radius 0.01    - (-r) minimum tree radius to consider" << std::endl;
     std::cout << "                            --girth_height_ratio 0.12 - (-i) the amount up tree's height to estimate trunk girth" << std::endl;
     std::cout << "                            --global_taper 0.024 - (-a) force a taper value (diameter per length) for trees under global_taper_factor of max tree height. Use 0 to estimate global taper from the data" << std::endl;
     std::cout << "                            --global_taper_factor 0.3- (-o) 1 estimates same taper for whole scan, 0 is per-tree tapering. Like a soft cutoff at this amount of max tree height" << std::endl;
     std::cout << "                            --gravity_factor 0.3 - (-f) larger values preference vertical trees" << std::endl;
     std::cout << "                            --branch_segmentation- (-b) _segmented.ply is per branch segment" << std::endl;
     std::cout << "                            --grid_width 10      - (-w) crops results assuming cloud has been gridded with given width" << std::endl;
+    std::cout << "                            --interest_zone_left_corner 0,0,0 - crops results using grid_width from given left bottom corner" << std::endl;
     std::cout << "                            --use_rays           - (-u) use rays to reduce trunk radius overestimation in noisy cloud data" << std::endl;
     std::cout << "                            (for internal constants -c -g -s see source file rayextract)" << std::endl;
   // These are the internal parameters that I don't expose as they are 'advanced' only, you shouldn't need to adjust them
@@ -76,7 +80,7 @@ void usage(int exit_code = 1)
     std::cout << "                            --leaf_area 0.002    - area for each leaf." << std::endl;
     std::cout << "                            --leaf_droop 0.1     - drop per square horizontal distance." << std::endl;
     std::cout << "                            --stalks             - include stalks to closest branch." << std::endl;
-    std::cout << "                                 --verbose  - extra debug output." << std::endl;
+    std::cout << "                            --verbose  - extra debug output." << std::endl;
   }
   // clang-format on
   exit(exit_code);
@@ -92,19 +96,26 @@ int rayExtract(int argc, char *argv[])
   }
   ray::FileArgument cloud_file, mesh_file, trunks_file, trees_file, leaf_file;
   ray::TextArgument forest("forest"), trees("trees"), trunks("trunks"), terrain("terrain"), leaves("leaves");
+
+  ray::Vector3dArgument interest_zone_left_corner(-200, 200,
+                                                  Eigen::Vector3d::Constant(std::numeric_limits<double>::quiet_NaN()));
+  ray::Optional3DVectorArgument interest_zone_left_corner_option("interest_zone_left_corner",
+                                                                 &interest_zone_left_corner);
   ray::OptionalKeyValueArgument groundmesh_option("ground", 'g', &mesh_file);
   ray::OptionalKeyValueArgument trunks_option("trunks", 't', &trunks_file);
+
   ray::DoubleArgument gradient(0.001, 1000.0, 1.0), global_taper(0.0, 1.0), global_taper_factor(0.0, 1.0);
   ray::OptionalKeyValueArgument gradient_option("gradient", 'g', &gradient);
-  ray::OptionalFlagArgument exclude_rays("exclude_rays", 'e'), segment_branches("branch_segmentation", 'b'), stalks("stalks", 's'), use_rays("use_rays", 'u');
+  ray::OptionalFlagArgument exclude_rays("exclude_rays", 'e'), segment_branches("branch_segmentation", 'b'),
+    stalks("stalks", 's'), use_rays("use_rays", 'u');
   ray::DoubleArgument width(0.01, 10.0, 0.25), drop(0.001, 1.0), max_gradient(0.01, 5.0), min_gradient(0.01, 5.0);
 
   ray::DoubleArgument max_diameter(0.01, 100.0), distance_limit(0.01, 10.0), height_min(0.01, 1000.0),
-    min_diameter(0.01, 100.0), leaf_area(0.00001, 1.0, 0.002), leaf_droop(0.0, 10.0, 0.1), crop_length(0.01, 100.0);;
-  ray::DoubleArgument girth_height_ratio(0.001, 0.5), length_to_radius(0.01, 10000.0), cylinder_length_to_width(0.1, 20.0), gap_ratio(0.01, 10.0),
-    span_ratio(0.01, 10.0);
-  ray::DoubleArgument gravity_factor(0.0, 100.0), grid_width(1.0, 100000.0),
-    grid_overlap(0.0, 0.9);
+    min_diameter(0.01, 100.0), leaf_area(0.00001, 1.0, 0.002), leaf_droop(0.0, 10.0, 0.1), crop_length(0.01, 100.0);
+
+  ray::DoubleArgument girth_height_ratio(0.001, 0.5), length_to_radius(0.01, 10000.0),
+    cylinder_length_to_width(0.1, 20.0), gap_ratio(0.01, 10.0), span_ratio(0.01, 10.0), min_radius(0.01, 100.0);
+  ray::DoubleArgument gravity_factor(0.0, 100.0), grid_width(1.0, 100000.0), grid_overlap(0.0, 0.9);
   ray::OptionalKeyValueArgument max_diameter_option("max_diameter", 'm', &max_diameter);
   ray::OptionalKeyValueArgument crop_length_option("crop_length", 'n', &crop_length);
   ray::OptionalKeyValueArgument distance_limit_option("distance_limit", 'd', &distance_limit);
@@ -112,6 +123,8 @@ int rayExtract(int argc, char *argv[])
   ray::OptionalKeyValueArgument girth_height_ratio_option("girth_height_ratio", 'i', &girth_height_ratio);
   ray::OptionalKeyValueArgument cylinder_length_to_width_option("cylinder_length_to_width", 'c',
                                                                 &cylinder_length_to_width);
+
+  ray::OptionalKeyValueArgument min_radius_option("min_radius", 'r', &min_radius);
   ray::OptionalKeyValueArgument gap_ratio_option("gap_ratio", 'g', &gap_ratio);
   ray::OptionalKeyValueArgument span_ratio_option("span_ratio", 's', &span_ratio);
   ray::OptionalKeyValueArgument gravity_factor_option("gravity_factor", 'f', &gravity_factor);
@@ -137,9 +150,10 @@ int rayExtract(int argc, char *argv[])
     argc, argv, { &trees, &cloud_file, &mesh_file },
     { &max_diameter_option, &distance_limit_option, &height_min_option, &crop_length_option, &girth_height_ratio_option,
       &cylinder_length_to_width_option, &gap_ratio_option, &span_ratio_option, &gravity_factor_option,
-      &segment_branches, &grid_width_option, &global_taper_option, &global_taper_factor_option, &use_rays, &verbose });
-  bool extract_leaves = ray::parseCommandLine(argc, argv, { &leaves, &cloud_file, &trees_file }, { &leaf_option, &leaf_area_option, &leaf_droop_option, &stalks });
-
+      &segment_branches, &grid_width_option, &global_taper_option, &global_taper_factor_option, &use_rays, &verbose,
+      &interest_zone_left_corner_option, &min_radius_option });
+  bool extract_leaves = ray::parseCommandLine(argc, argv, { &leaves, &cloud_file, &trees_file },
+                                              { &leaf_option, &leaf_area_option, &leaf_droop_option, &stalks });
 
   if (!extract_trunks && !extract_forest && !extract_terrain && !extract_trees && !extract_leaves)
   {
@@ -226,8 +240,16 @@ int rayExtract(int argc, char *argv[])
     if (global_taper_factor_option.isSet())
     {
       params.global_taper_factor = global_taper_factor.value();
-    }   
-    params.use_rays = use_rays.isSet(); 
+    }
+    if (interest_zone_left_corner_option.isSet())
+    {
+      params.interest_zone_left_corner = interest_zone_left_corner.value();
+    }
+    if (min_radius_option.isSet())
+    {
+      params.min_radius = min_radius.value();
+    }
+    params.use_rays = use_rays.isSet();
     params.segment_branches = segment_branches.isSet();
 
     ray::Trees trees(cloud, offset, mesh, params, verbose.isSet());
@@ -247,7 +269,7 @@ int rayExtract(int argc, char *argv[])
     }
     ray::Mesh tree_mesh;
     forest.generateSmoothMesh(tree_mesh, -1, 1, 1, 1);
-    ray::writePlyMesh(cloud_file.nameStub() + "_trees_mesh.ply", tree_mesh, true);    
+    ray::writePlyMesh(cloud_file.nameStub() + "_trees_mesh.ply", tree_mesh, true);
   }
   // extract the tree locations from a larger, aerial view of a forest
   else if (extract_forest)
@@ -305,8 +327,8 @@ int rayExtract(int argc, char *argv[])
   }
   else if (extract_leaves)
   {
-    ray::generateLeaves(cloud_file.nameStub(), trees_file.name(), leaf_file.name(), 
-      leaf_area.value(), leaf_droop.value(), stalks.isSet());
+    ray::generateLeaves(cloud_file.nameStub(), trees_file.name(), leaf_file.name(), leaf_area.value(),
+                        leaf_droop.value(), stalks.isSet());
   }
   else
   {

--- a/raycloudtools/rayimport/rayimport.cpp
+++ b/raycloudtools/rayimport/rayimport.cpp
@@ -46,11 +46,16 @@ int rayImport(int argc, char *argv[])
   bool ray_format =
     ray::parseCommandLine(argc, argv, { &cloud_file, &ray_text, &ray_vec }, { &max_intensity_option, &remove });
   if (!standard_format && !position_format && !ray_format)
+  {
     usage();
+  }
+
 
   if (ray_format && ray_vec.value().norm() == 0.0)
   {
-    std::cerr << "Error: some ray cloud functions require rays to have a length. Please enter a non-zero vector for ray argument" << std::endl;
+    std::cerr << "Error: some ray cloud functions require rays to have a length. Please enter a non-zero vector for "
+                 "ray argument"
+              << std::endl;
     usage();
   }
   ray::Cloud cloud;
@@ -78,7 +83,10 @@ int rayImport(int argc, char *argv[])
       else
       {
         if (!ray::readLas(traj_file, ends, times, colours, maximum_intensity))
+        {
+          std::cerr << "Failed to read las file" << std::endl;
           return false;
+        }
       }
       trajectory.points() = std::move(ends);
       trajectory.times() = std::move(times);
@@ -100,8 +108,7 @@ int rayImport(int argc, char *argv[])
   double min_time = std::numeric_limits<double>::max();
   double max_time = std::numeric_limits<double>::lowest();
   auto add_chunk = [&](std::vector<Eigen::Vector3d> &starts, std::vector<Eigen::Vector3d> &ends,
-                       std::vector<double> &times, std::vector<ray::RGBA> &colours) 
-  {
+                       std::vector<double> &times, std::vector<ray::RGBA> &colours) {
     if (start_pos.squaredNorm() == 0.0)
     {
       start_pos = ends[0];
@@ -111,7 +118,7 @@ int rayImport(int argc, char *argv[])
     {
       starts = ends;
       Eigen::Vector3d pos = position.value();
-      for (auto &start : starts) 
+      for (auto &start : starts)
       {
         start = pos;
       }
@@ -122,7 +129,7 @@ int rayImport(int argc, char *argv[])
     {
       starts = ends;
       Eigen::Vector3d offset = -ray_vec.value();
-      for (auto &start : starts) 
+      for (auto &start : starts)
       {
         start += offset;
       }
@@ -148,18 +155,18 @@ int rayImport(int argc, char *argv[])
     // this is particularly useful if we are storing the ray cloud positions using floats
     if (remove.isSet())
     {
-      for (auto &end : ends) 
+      for (auto &end : ends)
       {
         end -= start_pos;
       }
-      for (auto &start : starts) 
+      for (auto &start : starts)
       {
         start -= start_pos;
       }
     }
     if (maximum_intensity == 0.0)
     {
-      for (auto &c : colours) 
+      for (auto &c : colours)
       {
         c.alpha = 255;
       }
@@ -173,8 +180,8 @@ int rayImport(int argc, char *argv[])
   if (cloud_file.nameExt() == "ply")
   {
     bool can_times_be_missing = position_format || ray_format;
-    if (!ray::readPly(cloud_file.name(), false, add_chunk,
-                      maximum_intensity, can_times_be_missing))  // special case of reading a non-ray-cloud ply
+    if (!ray::readPly(cloud_file.name(), false, add_chunk, maximum_intensity,
+                      can_times_be_missing))  // special case of reading a non-ray-cloud ply
     {
       usage();
     }
@@ -196,18 +203,20 @@ int rayImport(int argc, char *argv[])
     const float grace_period = 30.0;
     if (trajectory.times()[0] < min_time - grace_period)
     {
-      std::cout << "trajectory begins " << min_time - trajectory.times()[0] << " s before first point cloud time" << std::endl;
+      std::cout << "trajectory begins " << min_time - trajectory.times()[0] << " s before first point cloud time"
+                << std::endl;
     }
     if (trajectory.times().back() > max_time + grace_period)
     {
-      std::cout << "trajectory ends " << trajectory.times().back() - max_time << " s after last point cloud time" << std::endl;
+      std::cout << "trajectory ends " << trajectory.times().back() - max_time << " s after last point cloud time"
+                << std::endl;
     }
-    if (min_time < trajectory.times()[0]-grace_period || max_time > trajectory.times().back()+grace_period
-     || min_time > trajectory.times().back() || max_time < trajectory.times()[0])
+    if (min_time < trajectory.times()[0] - grace_period || max_time > trajectory.times().back() + grace_period ||
+        min_time > trajectory.times().back() || max_time < trajectory.times()[0])
     {
       std::cerr.precision(10);
-      std::cerr << "Error: trajectory times " << trajectory.times()[0] << "-" << trajectory.times().back() << 
-        " do not span the point cloud times " << min_time << "-" << max_time << std::endl;
+      std::cerr << "Error: trajectory times " << trajectory.times()[0] << "-" << trajectory.times().back()
+                << " do not span the point cloud times " << min_time << "-" << max_time << std::endl;
       usage();
     }
   }

--- a/raylib/extraction/raysegment.cpp
+++ b/raylib/extraction/raysegment.cpp
@@ -5,15 +5,16 @@
 // Author: Thomas Lowe
 #include "raysegment.h"
 #include <nabo/nabo.h>
-#include "rayterrain.h"
 #include <queue>
+#include "rayterrain.h"
+
 
 namespace ray
 {
 /// nodes of priority queue used in shortest path algorithm
 struct QueueNode
 {
-//  QueueNode() {}
+  //  QueueNode() {}
   QueueNode(double distance_to_ground, double score, double radius, int root, int index)
     : distance_to_ground(distance_to_ground)
     , score(score)
@@ -22,11 +23,11 @@ struct QueueNode
     , id(index)
   {}
 
-  double distance_to_ground; // path distance to the ground
-  double score;              // score is the modified edge length metric being minimised
-  double radius;             // radius of the tree base, this acts as a score scale coefficient
-  int root;                  // index of the root of the path
-  int id;                    // index into the points_ array for this node
+  double distance_to_ground;  // path distance to the ground
+  double score;               // score is the modified edge length metric being minimised
+  double radius;              // radius of the tree base, this acts as a score scale coefficient
+  int root;                   // index of the root of the path
+  int id;                     // index into the points_ array for this node
 };
 
 class QueueNodeComparator
@@ -53,6 +54,7 @@ void connectPointsShortestPath(
     points_p.col(i) = points[i].pos;
   }
   Nabo::NNSearchD *nns = Nabo::NNSearchD::createKDTreeLinearHeap(points_p, 3);
+
   // Run the search
   Eigen::MatrixXi indices;
   Eigen::MatrixXd dists2;
@@ -89,6 +91,7 @@ void connectPointsShortestPath(
             dir = (points[node.id].pos - points[ppar].pos).normalized();
           }
         }
+
         const double d = std::max(0.001, dif.dot(dir));
         // we are looking for a minimum score, so large distances are bad, but new points in line with the
         // path direction are good
@@ -151,10 +154,9 @@ std::vector<std::vector<int>> getRootsAndSegment(std::vector<Vertex> &points, co
   const int roots_start = static_cast<int>(points.size());
   for (auto &vert : mesh.vertices())
   {
-    if (vert[0] >= box_min[0] && vert[1] >= box_min[1] &&
-        vert[0] <= box_max[0] && vert[1] <= box_max[1])
+    if (vert[0] >= box_min[0] && vert[1] >= box_min[1] && vert[0] <= box_max[0] && vert[1] <= box_max[1])
     {
-      points.push_back(Vertex(vert, vert + Eigen::Vector3d(0,0,0.01))); // make small vertical ray
+      points.push_back(Vertex(vert, vert + Eigen::Vector3d(0, 0, 0.01)));  // make small vertical ray
     }
   }
   // convert the ground mesh to an easy look-up height field
@@ -162,8 +164,8 @@ std::vector<std::vector<int>> getRootsAndSegment(std::vector<Vertex> &points, co
   mesh.toHeightField(lowfield, box_min, box_max, pixel_width);
 
   // set heightfield as the height of the canopy above the ground
-  Eigen::ArrayXXd heightfield =
-    Eigen::ArrayXXd::Constant(static_cast<int>(lowfield.rows()), static_cast<int>(lowfield.cols()), std::numeric_limits<double>::lowest());
+  Eigen::ArrayXXd heightfield = Eigen::ArrayXXd::Constant(
+    static_cast<int>(lowfield.rows()), static_cast<int>(lowfield.cols()), std::numeric_limits<double>::lowest());
   for (const auto &point : points)
   {
     Eigen::Vector3i index = ((point.pos - box_min) / pixel_width).cast<int>();

--- a/raylib/extraction/raysegment.h
+++ b/raylib/extraction/raysegment.h
@@ -14,12 +14,12 @@
 
 namespace ray
 {
-
 /// Vertex structure used in shortest path algorithm
 struct RAYLIB_EXPORT Vertex
 {
   Vertex(const Eigen::Vector3d &pos, const Eigen::Vector3d &start)
-    : pos(pos), start(start)
+    : pos(pos)
+    , start(start)
     , parent(-1)
     , root(-1)
     , distance_to_ground(std::numeric_limits<double>::max())
@@ -42,8 +42,9 @@ struct RAYLIB_EXPORT Vertex
 /// @c max_diameter maximum diameter of a tree trunk
 /// @c distance_limit maximum distance between points that can be connected
 /// @c gravity_factor controls how far laterally the shortest paths can travel
-std::vector<std::vector<int>> RAYLIB_EXPORT getRootsAndSegment(std::vector<Vertex> &points, const Cloud &cloud, const Mesh &mesh,
-                                                               double max_diameter, double distance_limit, double height_min,
+std::vector<std::vector<int>> RAYLIB_EXPORT getRootsAndSegment(std::vector<Vertex> &points, const Cloud &cloud,
+                                                               const Mesh &mesh, double max_diameter,
+                                                               double distance_limit, double height_min,
                                                                double gravity_factor);
 
 }  // namespace ray

--- a/raylib/extraction/raytrees.cpp
+++ b/raylib/extraction/raytrees.cpp
@@ -7,6 +7,7 @@
 #include <nabo/nabo.h>
 #include "rayclusters.h"
 
+
 namespace ray
 {
 TreesParams::TreesParams()
@@ -36,6 +37,7 @@ Trees::Trees(Cloud &cloud, const Eigen::Vector3d &offset, const Mesh &mesh, cons
   std::vector<std::vector<int>> roots_list = getRootsAndSegment(
     points_, cloud, mesh, params_->max_diameter, params_->distance_limit, params_->height_min, params_->gravity_factor);
 
+
   // Now we want to convert these paths into a set of branch sections, from root to tips
   // splitting as we go up...
 
@@ -57,6 +59,7 @@ Trees::Trees(Cloud &cloud, const Eigen::Vector3d &offset, const Mesh &mesh, cons
 
   // first do a special case for all the trunks. This is where we estimate mean taper
   ray::Cloud debug_cloud;
+
   for (sec_ = 0; sec_ < (int)sections_.size(); sec_++)
   {
     double best_accuracy = -1.0;
@@ -75,19 +78,19 @@ Trees::Trees(Cloud &cloud, const Eigen::Vector3d &offset, const Mesh &mesh, cons
     sections_[sec_].tree_height = tree_height;
 
     // Use a usr defined taper to control the height up the trunk to calculate the radius at
-    double girth_height = params_->girth_height_ratio * tree_height; // sections_[sec_].max_distance_to_end;
+    double girth_height = params_->girth_height_ratio * tree_height;  // sections_[sec_].max_distance_to_end;
     double estimated_radius = 1e10;
     double best_dist = 0.0;
     Eigen::Vector3d best_tip;
-    
+
     std::vector<int> best_nodes;
     std::vector<int> best_ends;
-    for (int j = 1; j<=3; j++)
+    for (int j = 1; j <= 3; j++)
     {
-      double max_dist = girth_height * (double)j / 2.0; // range from 0.5 to 1.5 times the specified height
+      double max_dist = girth_height * (double)j / 2.0;  // range from 0.5 to 1.5 times the specified height
       nodes.clear();
       sections_[sec_].ends.clear();
-      extractNodesAndEndsFromRoots(nodes, base, children, max_dist * 2.0/3.0, max_dist);
+      extractNodesAndEndsFromRoots(nodes, base, children, max_dist * 2.0 / 3.0, max_dist);
       if (nodes.size() < 2)
       {
         continue;
@@ -95,33 +98,36 @@ Trees::Trees(Cloud &cloud, const Eigen::Vector3d &offset, const Mesh &mesh, cons
       sections_[sec_].tip = calculateTipFromVertices(nodes);
       if (verbose)
       {
-        for (auto &node: nodes)
+        for (auto &node : nodes)
         {
-          debug_cloud.addRay(Eigen::Vector3d(0,0,0), points_[node].pos, 0.0, ray::RGBA(j==1 ? 255 : 0, j==2 ? 255:0, j==3 ? 255:0, 255));
+          debug_cloud.addRay(Eigen::Vector3d(0, 0, 0), points_[node].pos, 0.0,
+                             ray::RGBA(j == 1 ? 255 : 0, j == 2 ? 255 : 0, j == 3 ? 255 : 0, 255));
         }
-      }         
+      }
       if (removeDistantPoints(nodes))
       {
         sections_[sec_].tip = calculateTipFromVertices(nodes);
       }
       if (verbose)
       {
-        debug_cloud.addRay(Eigen::Vector3d(0,0,0), sections_[sec_].tip + Eigen::Vector3d(0,0,0.03), 0.0, ray::RGBA(255,255,0, 255));
+        debug_cloud.addRay(Eigen::Vector3d(0, 0, 0), sections_[sec_].tip + Eigen::Vector3d(0, 0, 0.03), 0.0,
+                           ray::RGBA(255, 255, 0, 255));
       }
       // shift to cylinder's centre
-      Eigen::Vector3d up(0,0,1);
+      Eigen::Vector3d up(0, 0, 1);
       sections_[sec_].tip += vectorToCylinderCentre(nodes, up);
       // now find the segment radius
       double accuracy;
       double radius = estimateCylinderRadius(nodes, up, accuracy);
 
-      ray::RGBA col(j==1 ? 255 : 127, j==2 ? 255:127, j==3 ? 255:127, 255);
+      ray::RGBA col(j == 1 ? 255 : 127, j == 2 ? 255 : 127, j == 3 ? 255 : 127, 255);
       if (verbose)
       {
-        debug_cloud.addRay(Eigen::Vector3d(0,0,0), sections_[sec_].tip, 0.0, col);
-        for (double ang = 0; ang < 2.0*ray::kPi; ang += 0.1)
+        debug_cloud.addRay(Eigen::Vector3d(0, 0, 0), sections_[sec_].tip, 0.0, col);
+        for (double ang = 0; ang < 2.0 * ray::kPi; ang += 0.1)
         {
-          debug_cloud.addRay(Eigen::Vector3d(0,0,0), sections_[sec_].tip + radius * Eigen::Vector3d(std::sin(ang), std::cos(ang),0), 0.0, col);
+          debug_cloud.addRay(Eigen::Vector3d(0, 0, 0),
+                             sections_[sec_].tip + radius * Eigen::Vector3d(std::sin(ang), std::cos(ang), 0), 0.0, col);
         }
       }
       if (radius < estimated_radius)
@@ -136,21 +142,30 @@ Trees::Trees(Cloud &cloud, const Eigen::Vector3d &offset, const Mesh &mesh, cons
     }
     if (best_dist == 0.0)
     {
-      std::cout << "warning: could not find any points on trunk " << sec_ << " at " << base.transpose() << " so removing the whole section" << std::endl;
-      sections_[sec_].tip = base + Eigen::Vector3d(0,0,0.01);
+      std::cout << "warning: could not find any points on trunk " << sec_ << " at " << base.transpose()
+                << " so removing the whole section" << std::endl;
+      sections_[sec_].tip = base + Eigen::Vector3d(0, 0, 0.01);
       sections_[sec_].total_weight = 1e-10;
-      sections_[sec_].ends.clear(); // so this trunk is not ever used
-      continue; 
-    }    
+      sections_[sec_].ends.clear();  // so this trunk is not ever used
+      continue;
+    }
+
+    if (params_->min_radius && estimated_radius < params_->min_radius)
+    {
+      sections_[sec_].tip = base + Eigen::Vector3d(0, 0, 0.01);
+      sections_[sec_].total_weight = 1e-10;
+      sections_[sec_].ends.clear();
+      continue;
+    }
     sections_[sec_].tip = best_tip;
     sections_[sec_].ends = best_ends;
     nodes = best_nodes;
     if (sections_[sec_].split_count < 2)
     {
-      double thickness = best_dist; 
+      double thickness = best_dist;
       bool points_removed = false;
-      double gap = params_->gap_ratio * sections_[sec_].max_distance_to_end; // gap threshold for splitting
-      double span = params_->span_ratio * estimated_radius; // span threshold for splitting
+      double gap = params_->gap_ratio * sections_[sec_].max_distance_to_end;  // gap threshold for splitting
+      double span = params_->span_ratio * estimated_radius;                   // span threshold for splitting
       std::vector<std::vector<int>> clusters = findPointClusters(base, points_removed, thickness, span, gap);
 
       if (clusters.size() > 1 || (points_removed && clusters.size() > 0))  // a bifurcation (or an alteration)
@@ -163,21 +178,25 @@ Trees::Trees(Cloud &cloud, const Eigen::Vector3d &offset, const Mesh &mesh, cons
     }
     if (verbose)
     {
-      for (auto &node: sections_[sec_].ends)
+      for (auto &node : sections_[sec_].ends)
       {
-        debug_cloud.addRay(Eigen::Vector3d(0,0,0), points_[node].pos + Eigen::Vector3d(0,0,0.02), 0.0, ray::RGBA(255, 0, 255, 255));
+        debug_cloud.addRay(Eigen::Vector3d(0, 0, 0), points_[node].pos + Eigen::Vector3d(0, 0, 0.02), 0.0,
+                           ray::RGBA(255, 0, 255, 255));
       }
-      for (double ang = 0; ang < 2.0*ray::kPi; ang += 0.1)
+      for (double ang = 0; ang < 2.0 * ray::kPi; ang += 0.1)
       {
-        uint8_t shade = 255; // (uint8_t)(best_accuracy * 255.0);
-        debug_cloud.addRay(Eigen::Vector3d(0,0,0), best_tip + (estimated_radius + 0.01) * Eigen::Vector3d(std::sin(ang), std::cos(ang),0), 0.0, ray::RGBA(shade,shade,shade,255));
+        uint8_t shade = 255;  // (uint8_t)(best_accuracy * 255.0);
+        debug_cloud.addRay(Eigen::Vector3d(0, 0, 0),
+                           best_tip + (estimated_radius + 0.01) * Eigen::Vector3d(std::sin(ang), std::cos(ang), 0), 0.0,
+                           ray::RGBA(shade, shade, shade, 255));
       }
     }
 
     nodes.clear();
     sections_[sec_].ends.clear();
-    extractNodesAndEndsFromRoots(nodes, base, children, 0.0, best_dist/2.0); // make it lower
-    estimateCylinderTaper(estimated_radius, best_accuracy, false); // update the expected taper
+    sections_[sec_].radius = estimated_radius;
+    extractNodesAndEndsFromRoots(nodes, base, children, 0.0, best_dist / 2.0);  // make it lower
+    estimateCylinderTaper(estimated_radius, best_accuracy, false);              // update the expected taper
   }
   if (verbose)
   {
@@ -196,11 +215,11 @@ Trees::Trees(Cloud &cloud, const Eigen::Vector3d &offset, const Mesh &mesh, cons
       if (sections_[sec_].ends.size() > 0)
       {
         addChildSection();
-        for (const auto &i: sections_[sec_].roots)
+        for (const auto &i : sections_[sec_].roots)
         {
           sections_[sec_].tip[2] = std::min(sections_[sec_].tip[2], points_[i].pos[2]);
         }
-      }      
+      }
       else
       {
         std::cout << "weird, a trunk without end points! " << sec_ << std::endl;
@@ -226,26 +245,27 @@ Trees::Trees(Cloud &cloud, const Eigen::Vector3d &offset, const Mesh &mesh, cons
     if (!extract_from_ends)
     {
       Eigen::Vector3d base = getRootPosition();
-      double span_rad = radius(sections_[sec_]); 
+      double span_rad = radius(sections_[sec_]);
       double thickness = params_->cylinder_length_to_width * span_rad;
       extractNodesAndEndsFromRoots(nodes, base, children, 0.0, thickness);
-      
+
       bool points_removed = false;
-      double gap = params_->gap_ratio * sections_[sec_].max_distance_to_end; // gap threshold for splitting
-      double span = params_->span_ratio * span_rad; // span thershold for splitting
+      double gap = params_->gap_ratio * sections_[sec_].max_distance_to_end;  // gap threshold for splitting
+      double span = params_->span_ratio * span_rad;                           // span thershold for splitting
       std::vector<std::vector<int>> clusters = findPointClusters(base, points_removed, thickness, span, gap);
 
       if (clusters.size() > 1 || (points_removed && clusters.size() > 0))  // a bifurcation (or an alteration)
       {
-        extract_from_ends = true; // don't trust the found nodes as it is now two separate tree nodes
-        bool add_offshoots = true; // par != -1 && sections_[par].parent != -1;  // when this is false it can lead to whole branches missing.
+        extract_from_ends = true;   // don't trust the found nodes as it is now two separate tree nodes
+        bool add_offshoots = true;  // par != -1 && sections_[par].parent != -1;  // when this is false it can lead to
+                                    // whole branches missing.
         // if points have been removed then this only resets the current section's points
         // otherwise it creates new branch sections_ for each cluster and adds to the end of the sections_ list
         bifurcate(clusters, thickness, children, false, add_offshoots);
       }
     }
 
-    if (extract_from_ends) // we have split the ends, so we need to extract the set of nodes in a backwards manner
+    if (extract_from_ends)  // we have split the ends, so we need to extract the set of nodes in a backwards manner
     {
       extractNodesFromEnds(nodes);
     }
@@ -277,10 +297,17 @@ Trees::Trees(Cloud &cloud, const Eigen::Vector3d &offset, const Mesh &mesh, cons
   generateLocalSectionIds();
 
   Eigen::Vector3d min_bound(0, 0, 0), max_bound(0, 0, 0);
-  // remove all sections with a root out of bounds, if we have gridded the cloud with an overlap
+  //  remove all sections with a root out of bounds, if we have gridded the cloud with an overlap
   if (params_->grid_width)
   {
-    removeOutOfBoundSections(cloud, min_bound, max_bound, offset);
+    if (!params_->interest_zone_left_corner.array().isNaN().any())
+    {
+      removeOutOfInterestSections(cloud, min_bound, max_bound, offset);
+    }
+    else
+    {
+      removeOutOfBoundSections(cloud, min_bound, max_bound, offset);
+    }
   }
 
   std::vector<int> root_segs(cloud.ends.size(), -1);
@@ -292,28 +319,29 @@ Trees::Trees(Cloud &cloud, const Eigen::Vector3d &offset, const Mesh &mesh, cons
     removeOutOfBoundRays(cloud, min_bound, max_bound, root_segs);
   }
 
-  std::cout << "cloud's estimated mean taper ratio (diameter / length): " << 2.0 * forest_taper_ / forest_weight_ << std::endl;
+  std::cout << "cloud's estimated mean taper ratio (diameter / length): " << 2.0 * forest_taper_ / forest_weight_
+            << std::endl;
 }
 
-// If 1 tree plus some low lying foliage is in the node, then it won't be split if the foliage doesn't reach to the 
-// top of the section (so doesn't have an end point), but it can create a very large radius estimate. 
-// here we remove points that are too far from any end position. 
-// this allows us to use most nodes to get an accurate radius estimate, but still uses only the end nodes to decide whether
-// to split
+// If 1 tree plus some low lying foliage is in the node, then it won't be split if the foliage doesn't reach to the
+// top of the section (so doesn't have an end point), but it can create a very large radius estimate.
+// here we remove points that are too far from any end position.
+// this allows us to use most nodes to get an accurate radius estimate, but still uses only the end nodes to decide
+// whether to split
 bool Trees::removeDistantPoints(std::vector<int> &nodes)
 {
-  Eigen::Vector3d up(0,0,1);
-  double max_rad = params_->gap_ratio * sections_[sec_].max_distance_to_end; // gap threshold for splitting
+  Eigen::Vector3d up(0, 0, 1);
+  double max_rad = params_->gap_ratio * sections_[sec_].max_distance_to_end;  // gap threshold for splitting
   double max_rad_sqr = max_rad * max_rad;
   bool found = false;
-  for (int k = 0; k<(int)nodes.size(); k++)
+  for (int k = 0; k < (int)nodes.size(); k++)
   {
     if (nodes.size() <= 6)
     {
       break;
     }
     bool all_distant = true;
-    for (auto &end: sections_[sec_].ends)
+    for (auto &end : sections_[sec_].ends)
     {
       Eigen::Vector3d dif = points_[nodes[k]].pos - points_[end].pos;
       dif[2] = 0.0;
@@ -345,18 +373,20 @@ double Trees::meanTaper(const BranchSection &section) const
   mean_weight *= blend;
   weight *= 1.0 - blend;
 
-  double result = (mean_taper * mean_weight + taper*weight) / (mean_weight + weight);
+  double result = (mean_taper * mean_weight + taper * weight) / (mean_weight + weight);
   if (!(result == result))
   {
     std::cout << "bad taper estimate" << std::endl;
-    std::cout << "root: " << root << " estimated taper: " << result << ", mt: " << mean_taper << ", mw: " << mean_weight << ", t: " << taper << ", w: " << weight << ", blend: " << blend << std::endl;
+    std::cout << "root: " << root << " estimated taper: " << result << ", mt: " << mean_taper << ", mw: " << mean_weight
+              << ", t: " << taper << ", w: " << weight << ", blend: " << blend << std::endl;
   }
   return result;
 }
 
-double Trees::radius(const BranchSection &section) const 
-{ 
-  return sections_[section.root].tree_height * meanTaper(section) * section.radius_scale; // scaled down from root's estimated radius
+double Trees::radius(const BranchSection &section) const
+{
+  return sections_[section.root].tree_height * meanTaper(section) *
+         section.radius_scale;  // scaled down from root's estimated radius
 }
 
 void Trees::calculatePointDistancesToEnd()
@@ -447,7 +477,8 @@ Eigen::Vector3d Trees::getRootPosition() const
 // note that the nodes contain everything between min_dist and max_dist and also the adjacent nodes either side
 // i.e. a root node and an end node. This means the minimum number of nodes is 2
 void Trees::extractNodesAndEndsFromRoots(std::vector<int> &nodes, const Eigen::Vector3d &base,
-                                         const std::vector<std::vector<int>> &children, double min_dist, double max_dist)
+                                         const std::vector<std::vector<int>> &children, double min_dist,
+                                         double max_dist)
 {
   const int par = sections_[sec_].parent;
   std::vector<int> iteration_nodes = sections_[sec_].roots;
@@ -487,7 +518,7 @@ void Trees::extractNodesAndEndsFromRoots(std::vector<int> &nodes, const Eigen::V
 
 // find clusters of points from the root points up the shortest paths, up to the cylinder length
 std::vector<std::vector<int>> Trees::findPointClusters(const Eigen::Vector3d &base, bool &points_removed,
-                              double thickness, double span, double gap)
+                                                       double thickness, double span, double gap)
 {
   const int par = sections_[sec_].parent;
   std::vector<int> &all_ends = sections_[sec_].ends;
@@ -548,7 +579,8 @@ std::vector<std::vector<int>> Trees::findPointClusters(const Eigen::Vector3d &ba
 
 // split into multiple branches and add as new branch sections to the end of the sections_ list
 // that is being iterated through.
-void Trees::bifurcate(const std::vector<std::vector<int>> &clusters, double thickness, std::vector<std::vector<int>> &children, bool clip_tree, bool add_offshoots)
+void Trees::bifurcate(const std::vector<std::vector<int>> &clusters, double thickness,
+                      std::vector<std::vector<int>> &children, bool clip_tree, bool add_offshoots)
 {
   const int par = sections_[sec_].parent;
   // find the maximum distance (to tip) for each cluster
@@ -570,14 +602,14 @@ void Trees::bifurcate(const std::vector<std::vector<int>> &clusters, double thic
   }
 
   double total_area = 0.0;
-  for (auto &dist: max_distances)
+  for (auto &dist : max_distances)
   {
     total_area += dist * dist;
   }
 
   // if clip_tree then we need to change the root nodes to be only those ones that
-  // each path goes to... 
-  
+  // each path goes to...
+
   // set the current branch section to the cluster with the
   // maximum distance to tip (i.e. the longest branch).
   sections_[sec_].ends = clusters[maxi];
@@ -640,9 +672,9 @@ void Trees::bifurcate(const std::vector<std::vector<int>> &clusters, double thic
             int child = end;
             while (node != -1)
             {
-              if (std::find(my_nodes.begin(), my_nodes.end(), node) != my_nodes.end()) 
+              if (std::find(my_nodes.begin(), my_nodes.end(), node) != my_nodes.end())
               {
-                break; // just hit my own tree
+                break;  // just hit my own tree
               }
               if (std::find(all_nodes.begin(), all_nodes.end(), node) != all_nodes.end())
               {
@@ -652,7 +684,7 @@ void Trees::bifurcate(const std::vector<std::vector<int>> &clusters, double thic
                 auto &list = children[node];
 
                 int find_count = 0;
-                for (int j = 0; j<(int)list.size(); j++)
+                for (int j = 0; j < (int)list.size(); j++)
                 {
                   if (list[j] == child)
                   {
@@ -665,8 +697,8 @@ void Trees::bifurcate(const std::vector<std::vector<int>> &clusters, double thic
                 points_[child].parent = -1;
 
                 // we need to tell all of the children what the new root is
-                std::vector<int> child_list = {child};
-                for (size_t j = 0; j<child_list.size(); j++)
+                std::vector<int> child_list = { child };
+                for (size_t j = 0; j < child_list.size(); j++)
                 {
                   points_[child_list[j]].root = child;
                   child_list.insert(child_list.end(), children[child_list[j]].begin(), children[child_list[j]].end());
@@ -674,7 +706,8 @@ void Trees::bifurcate(const std::vector<std::vector<int>> &clusters, double thic
                 break;
               }
               my_nodes.push_back(node);  // fill in the nodes in this branch section
-              if (std::find(sections_[sec_].roots.begin(), sections_[sec_].roots.end(), node) != sections_[sec_].roots.end())
+              if (std::find(sections_[sec_].roots.begin(), sections_[sec_].roots.end(), node) !=
+                  sections_[sec_].roots.end())
               {
                 my_roots.push_back(node);
                 break;
@@ -705,7 +738,8 @@ void Trees::bifurcate(const std::vector<std::vector<int>> &clusters, double thic
   }
   if (par > -1)
   {
-    sections_[sec_].radius_scale *= max_distances[maxi] / std::sqrt(total_area); // reduce branch radius due to the split
+    sections_[sec_].radius_scale *=
+      max_distances[maxi] / std::sqrt(total_area);  // reduce branch radius due to the split
   }
 }
 
@@ -832,7 +866,7 @@ double Trees::estimateCylinderRadius(const std::vector<int> &nodes, const Eigen:
 {
   double rad = 0.0;
   // get the mean radius
-  double power = 0.25; // when 1 this is usual radius, but lower powers reduce outliers due to foliage
+  double power = 0.25;  // when 1 this is usual radius, but lower powers reduce outliers due to foliage
   std::vector<double> norms;
   norms.reserve(nodes.size());
   if (params_->use_rays)
@@ -840,10 +874,10 @@ double Trees::estimateCylinderRadius(const std::vector<int> &nodes, const Eigen:
     for (auto &node : nodes)
     {
       Eigen::Vector3d offset = points_[node].pos - sections_[sec_].tip;
-      offset -= dir * offset.dot(dir); // flatten    
+      offset -= dir * offset.dot(dir);  // flatten
       Eigen::Vector3d ray = points_[node].start - points_[node].pos;
-      ray -= dir * ray.dot(dir); // flatten
-      offset += ray*std::max(0.0, std::min(-offset.dot(ray)/ray.dot(ray), 1.0)); // move to closest point
+      ray -= dir * ray.dot(dir);                                                      // flatten
+      offset += ray * std::max(0.0, std::min(-offset.dot(ray) / ray.dot(ray), 1.0));  // move to closest point
       norms.push_back(offset.norm());
     }
   }
@@ -852,18 +886,18 @@ double Trees::estimateCylinderRadius(const std::vector<int> &nodes, const Eigen:
     for (auto &node : nodes)
     {
       Eigen::Vector3d offset = points_[node].pos - sections_[sec_].tip;
-      offset -= dir * offset.dot(dir); // flatten    
+      offset -= dir * offset.dot(dir);  // flatten
       norms.push_back(offset.norm());
     }
   }
 
-  for (auto &norm: norms)
+  for (auto &norm : norms)
   {
     rad += std::pow(norm, power);
   }
-  const double eps = 1e-5; // prevent division by 0
+  const double eps = 1e-5;  // prevent division by 0
   rad /= (double)nodes.size() + eps;
-  rad = std::pow(rad, 1.0/power);
+  rad = std::pow(rad, 1.0 / power);
   double e = 0.0;
   for (auto &norm : norms)
   {
@@ -872,10 +906,12 @@ double Trees::estimateCylinderRadius(const std::vector<int> &nodes, const Eigen:
   e /= (double)nodes.size() + eps;
 #define NEW_ACCURACY
 #if defined NEW_ACCURACY
-  const double sensor_noise = 0.02; // this prevents cylinders with a small number of very accurate points from totally dominating
+  const double sensor_noise =
+    0.02;  // this prevents cylinders with a small number of very accurate points from totally dominating
   accuracy = rad / (e + sensor_noise);
-#else // this one goes down to 0, which could be bad if all cylinder points were low accuracy
-  accuracy = std::max(eps, rad - 2.0*e) / std::max(eps, rad); // so even distribution is accuracy 0, and cylinder shell is accuracy 1 
+#else  // this one goes down to 0, which could be bad if all cylinder points were low accuracy
+  accuracy = std::max(eps, rad - 2.0 * e) /
+             std::max(eps, rad);  // so even distribution is accuracy 0, and cylinder shell is accuracy 1
   accuracy *= std::min((double)nodes.size() / 3.0, 1.0);
 #endif
   accuracy = std::max(accuracy, eps);
@@ -895,16 +931,17 @@ void Trees::estimateCylinderTaper(double radius, double accuracy, bool extract_f
   double junction_weight = 1.0;
   if (par > -1)
   {
-    junction_weight = extract_from_ends ? 0.25 : 1.0; // extracting from ends means we are less confident about the quality
+    junction_weight =
+      extract_from_ends ? 0.25 : 1.0;  // extracting from ends means we are less confident about the quality
   }
 
-  double weight = l*l*l * accuracy * junction_weight;
- // weight *= weight; // preference the strongest weight sections
-  double taper = (radius/L) * weight;
+  double weight = l * l * l * accuracy * junction_weight;
+  // weight *= weight; // preference the strongest weight sections
+  double taper = (radius / L) * weight;
 
   forest_taper_ += taper;
   forest_weight_ += weight;
-  forest_weight_squared_ += weight*weight;
+  forest_weight_squared_ += weight * weight;
 
   sections_[root].total_taper += taper;
   sections_[root].total_weight += weight;
@@ -916,7 +953,7 @@ void Trees::estimateCylinderTaper(double radius, double accuracy, bool extract_f
 
   sections_[sec_].taper = taper;
   sections_[sec_].weight = weight;
-  sections_[sec_].len = l*l*l;
+  sections_[sec_].len = l * l * l;
   sections_[sec_].accuracy = accuracy;
   sections_[sec_].junction_weight = junction_weight;
 }
@@ -931,12 +968,12 @@ void Trees::addChildSection()
   new_node.taper = sections_[sec_].taper;
   new_node.weight = sections_[sec_].weight;
   new_node.radius_scale = sections_[sec_].radius_scale;
-  
+
   for (auto &root : new_node.roots)
   {
     new_node.max_distance_to_end = std::max(new_node.max_distance_to_end, points_[root].distance_to_end);
   }
-  if (new_node.max_distance_to_end > params_->crop_length)  
+  if (new_node.max_distance_to_end > params_->crop_length)
   {
     sections_[sec_].children.push_back(static_cast<int>(sections_.size()));
     new_node.tip = calculateTipFromVertices(new_node.roots);
@@ -971,8 +1008,7 @@ void Trees::calculateSectionIds(std::vector<int> &section_ids, const std::vector
           break;
         }
         nodes.push_back(node);
-        if (std::find(sections_[sec_].roots.begin(), sections_[sec_].roots.end(), node) !=
-            sections_[sec_].roots.end())
+        if (std::find(sections_[sec_].roots.begin(), sections_[sec_].roots.end(), node) != sections_[sec_].roots.end())
         {
           break;
         }
@@ -1046,17 +1082,19 @@ void Trees::generateLocalSectionIds()
   std::cout << num << " trees saved" << std::endl;
 }
 
-void Trees::removeOutOfBoundSections(const Cloud &cloud, Eigen::Vector3d &min_bound, Eigen::Vector3d &max_bound, const Eigen::Vector3d &offset)
+void Trees::removeOutOfBoundSections(const Cloud &cloud, Eigen::Vector3d &min_bound, Eigen::Vector3d &max_bound,
+                                     const Eigen::Vector3d &offset)
 {
   const double width = params_->grid_width;
   cloud.calcBounds(&min_bound, &max_bound);
-  const Eigen::Vector3d mid = (min_bound + max_bound)/2.0 + offset;
+  const Eigen::Vector3d mid = (min_bound + max_bound) / 2.0 + offset;
   const Eigen::Vector2d inds(std::round(mid[0] / width), std::round(mid[1] / width));
   min_bound[0] = width * (inds[0] - 0.5) - offset[0];
   min_bound[1] = width * (inds[1] - 0.5) - offset[1];
   max_bound[0] = width * (inds[0] + 0.5) - offset[0];
   max_bound[1] = width * (inds[1] + 0.5) - offset[1];
-  std::cout << "min bound: " << (min_bound+offset).transpose() << ", max bound: " << (max_bound+offset).transpose() << std::endl;
+  std::cerr << "min bound: " << (min_bound + offset).transpose() << ", max bound: " << (max_bound + offset).transpose()
+            << " offset " << offset << std::endl;
 
   // disable trees out of bounds
   for (auto &section : sections_)
@@ -1073,10 +1111,42 @@ void Trees::removeOutOfBoundSections(const Cloud &cloud, Eigen::Vector3d &min_bo
   }
 }
 
+void Trees::removeOutOfInterestSections(const Cloud &cloud, Eigen::Vector3d &min_bound, Eigen::Vector3d &max_bound,
+                                        const Eigen::Vector3d &offset)
+{
+  const double width = params_->grid_width;
+  cloud.calcBounds(&min_bound, &max_bound);
+  const Eigen::Vector3d interest_zone_bottom_left = min_bound + params_->interest_zone_left_corner + offset;
+  const Eigen::Vector2d inds(std::round(interest_zone_bottom_left[0] / width),
+                             std::round(interest_zone_bottom_left[1] / width));
+  min_bound[0] = width * (inds[0]) - offset[0];
+  min_bound[1] = width * (inds[1]) - offset[1];
+  max_bound[0] = width * (inds[0] + 1) - offset[0];
+  max_bound[1] = width * (inds[1] + 1) - offset[1];
+
+  std::cerr << "Interest zone " << min_bound[0] << " " << min_bound[1] << " " << max_bound[0] << " " << max_bound[1]
+            << std::endl;
+
+  for (auto &section : sections_)
+  {
+    if (section.parent >= 0 || section.children.empty())
+    {
+      continue;
+    }
+
+    const Eigen::Vector3d pos = section.tip;
+    if (pos[0] < min_bound[0] || pos[0] > max_bound[0] || pos[1] < min_bound[1] || pos[1] > max_bound[1])
+    {
+      section.children.clear();  // make it a non-tree
+    }
+  }
+}
+
 // colour the cloud by tree id, or by branch segment id
 void Trees::segmentCloud(Cloud &cloud, std::vector<int> &root_segs, const std::vector<int> &section_ids)
 {
-  contiguous_section_ids_.resize(sections_.size(), -1); // these are different to the root section IDs as they exclude empty trees
+  contiguous_section_ids_.resize(sections_.size(),
+                                 -1);  // these are different to the root section IDs as they exclude empty trees
   int num_trees = 0;
   bool first_non_root = false;
   for (size_t sec = 0; sec < sections_.size(); sec++)
@@ -1106,21 +1176,22 @@ void Trees::segmentCloud(Cloud &cloud, std::vector<int> &root_segs, const std::v
       const int root_id = points_[j].root;
       root_segs[i] = root_id == -1 ? -1 : section_ids[root_id];
 
-      // This block places a cone of gradient 2 around the trunk direction, to remove the square of initial ground points
+      // This block places a cone of gradient 2 around the trunk direction, to remove the square of initial ground
+      // points
       if (seg != -1 && sections_[seg].parent == -1)
       {
-        Eigen::Vector3d dir(0,0,1e-10);
+        Eigen::Vector3d dir(0, 0, 1e-10);
         for (auto &child : sections_[seg].children)
         {
           dir += sections_[child].tip - sections_[seg].tip;
         }
         dir.normalize();
-        const double grad = 2.0; // larger cuts out a steeper (narrower) cone
-        Eigen::Vector3d base = sections_[seg].tip - grad*dir*radius(sections_[seg]);
+        const double grad = 2.0;  // larger cuts out a steeper (narrower) cone
+        Eigen::Vector3d base = sections_[seg].tip - grad * dir * radius(sections_[seg]);
         Eigen::Vector3d dif = cloud.ends[i] - base;
         double h = dif.dot(dir);
-        double w = (dif - dir*h).norm();
-        if (grad*w > h)
+        double w = (dif - dir * h).norm();
+        if (grad * w > h)
         {
           colour.red = colour.green = colour.blue = 0;
           continue;
@@ -1187,13 +1258,15 @@ bool Trees::save(const std::string &filename, const Eigen::Vector3d &offset, boo
     return false;
   }
   ofs << std::setprecision(4) << std::fixed;
-  ofs << "# Tree file. Optional per-tree attributes (e.g. 'height,crown_radius, ') followed by 'x,y,z,radius' and any additional per-segment attributes:" << std::endl;
-  ofs << "x,y,z,radius,parent_id,section_id"; // simple format
+  ofs << "# Tree file. Optional per-tree attributes (e.g. 'height,crown_radius, ') followed by 'x,y,z,radius' and any "
+         "additional per-segment attributes:"
+      << std::endl;
+  ofs << "x,y,z,radius,parent_id,section_id";  // simple format
   if (verbose)
   {
     ofs << ",weight,len,accuracy,junction_weight";
   }
-  ofs << std::endl;  
+  ofs << std::endl;
   for (size_t sec = 0; sec < sections_.size(); sec++)
   {
     const auto &section = sections_[sec];
@@ -1201,7 +1274,8 @@ bool Trees::save(const std::string &filename, const Eigen::Vector3d &offset, boo
     {
       continue;
     }
-    ofs << section.tip[0]+offset[0] << "," << section.tip[1]+offset[1] << "," << section.tip[2]+offset[2] << "," << radius(section) << ",-1," << sec;
+    ofs << section.tip[0] + offset[0] << "," << section.tip[1] + offset[1] << "," << section.tip[2] + offset[2] << ","
+        << radius(section) << ",-1," << sec;
     if (verbose)
     {
       ofs << "," << section.weight << "," << section.len << "," << section.accuracy << "," << section.junction_weight;
@@ -1215,7 +1289,8 @@ bool Trees::save(const std::string &filename, const Eigen::Vector3d &offset, boo
       {
         std::cout << "bad format: " << node.root << " != " << root << std::endl;
       }
-      ofs << ", " << node.tip[0]+offset[0] << "," << node.tip[1]+offset[1] << "," << node.tip[2]+offset[2] << "," << radius(node) << "," << sections_[node.parent].id << "," << contiguous_section_ids_[children[c]];
+      ofs << ", " << node.tip[0] + offset[0] << "," << node.tip[1] + offset[1] << "," << node.tip[2] + offset[2] << ","
+          << radius(node) << "," << sections_[node.parent].id << "," << contiguous_section_ids_[children[c]];
       if (verbose)
       {
         ofs << "," << node.weight << "," << node.len << "," << node.accuracy << "," << node.junction_weight;

--- a/raylib/extraction/raytrees.h
+++ b/raylib/extraction/raytrees.h
@@ -18,20 +18,23 @@ namespace ray
 struct RAYLIB_EXPORT TreesParams
 {
   TreesParams();
-  double max_diameter;              // maximum tree diameter. Trees wider than this may be segmented into multiple trees
-  double crop_length;               // distance to end of branch where it crops the branch, and doesn't generate further geometry
-  double distance_limit;            // maximum distance between points that can count as connected
-  double height_min;                // minimum height for a tree. Lower values are considered undergrowth and excluded
+  double max_diameter;    // maximum tree diameter. Trees wider than this may be segmented into multiple trees
+  double crop_length;     // distance to end of branch where it crops the branch, and doesn't generate further geometry
+  double distance_limit;  // maximum distance between points that can count as connected
+  double height_min;      // minimum height for a tree. Lower values are considered undergrowth and excluded
   double girth_height_ratio;        // how far up tree to measure girth
   double cylinder_length_to_width;  // the slenderness of the branch segment cylinders
   double gap_ratio;                 // max gap per branch length
   double span_ratio;                // points that span a larger width determine that a branch has become two
-  double gravity_factor;   // preferences branches that are less lateral, so penalises implausable horizontal branches
-  double grid_width;       // used on a grid cell with overlap, to remove trees with a base in the overlap zone
-  bool segment_branches;   // flag to output the ray cloud coloured by branch segment index rather than by tree index
-  double global_taper;     // forced global taper, uses global_taper_factor to define how much it is applied
-  double global_taper_factor; // 0 estimates per-tree tapering, 1 uses per-scan tapering, 0.5 is mid-way on mid-weight trees
-  bool use_rays; // use the full rays in order to estimate a smaller radius when points are not all on the real branch
+  double gravity_factor;  // preferences branches that are less lateral, so penalises implausable horizontal branches
+  double grid_width;      // used on a grid cell with overlap, to remove trees with a base in the overlap zone
+  bool segment_branches;  // flag to output the ray cloud coloured by branch segment index rather than by tree index
+  double global_taper;    // forced global taper, uses global_taper_factor to define how much it is applied
+  double
+    global_taper_factor;  // 0 estimates per-tree tapering, 1 uses per-scan tapering, 0.5 is mid-way on mid-weight trees
+  bool use_rays;  // use the full rays in order to estimate a smaller radius when points are not all on the real branch
+  Eigen::Vector3d interest_zone_left_corner;  // if using a grid, then this is the left corner of the interest zone
+  double min_radius;                          // minimum radius for a branch
 };
 
 struct BranchSection;  // forwards declaration
@@ -66,10 +69,11 @@ private:
   void extractNodesAndEndsFromRoots(std::vector<int> &nodes, const Eigen::Vector3d &base,
                                     const std::vector<std::vector<int>> &children, double min_dist, double max_dist);
   /// find separate clusters of points within the branch section
-  std::vector<std::vector<int>> findPointClusters(const Eigen::Vector3d &base, bool &points_removed,
-                                                  double thickness, double span, double gap);
+  std::vector<std::vector<int>> findPointClusters(const Eigen::Vector3d &base, bool &points_removed, double thickness,
+                                                  double span, double gap);
   /// split the branch section to one branch for each cluster
-  void bifurcate(const std::vector<std::vector<int>> &clusters, double thickness, std::vector<std::vector<int>> &children, bool clip_tree, bool add_offshoots);
+  void bifurcate(const std::vector<std::vector<int>> &clusters, double thickness,
+                 std::vector<std::vector<int>> &children, bool clip_tree, bool add_offshoots);
   /// find the points within the branch section from its end points
   void extractNodesFromEnds(std::vector<int> &nodes);
   /// set the branch section tip position from the supplied list of Vertex IDs
@@ -87,7 +91,11 @@ private:
   /// set ids that are locel (0-based) per tree
   void generateLocalSectionIds();
   /// if using an overlapping grid, then remove trees with base outside the non-overlapping cell bounds
-  void removeOutOfBoundSections(const Cloud &cloud, Eigen::Vector3d &min_bound, Eigen::Vector3d &max_bound, const Eigen::Vector3d &offset);
+  void removeOutOfBoundSections(const Cloud &cloud, Eigen::Vector3d &min_bound, Eigen::Vector3d &max_bound,
+                                const Eigen::Vector3d &offset);
+  /// if using overlappng grid and interest zone, then remove trees with base outside of the interest zone
+  void removeOutOfInterestSections(const Cloud &cloud, Eigen::Vector3d &min_bound, Eigen::Vector3d &max_bound,
+                                   const Eigen::Vector3d &offset);
   /// colour the cloud based on the section id for each point
   void segmentCloud(Cloud &cloud, std::vector<int> &root_segs, const std::vector<int> &section_ids);
   /// remove points from the ray cloud if outside of the non-overlapping grid cell bounds
@@ -104,11 +112,11 @@ private:
   int sec_;
   const TreesParams *params_;
   std::vector<Vertex> points_;
-  double forest_taper_{0};
-  double forest_weight_{0};
-  double forest_weight_squared_{0};
-  std::vector<int> contiguous_section_ids_; // converts section ids to contiguous (empty trees removed) sectino ids for output
-
+  double forest_taper_{ 0 };
+  double forest_weight_{ 0 };
+  double forest_weight_squared_{ 0 };
+  std::vector<int>
+    contiguous_section_ids_;  // converts section ids to contiguous (empty trees removed) sectino ids for output
 };
 
 /// The structure for a single (cylindrical) branch section
@@ -130,6 +138,7 @@ struct RAYLIB_EXPORT BranchSection
     , radius_scale(1)
     , split_count(0)
     , tree_height(0)
+    , radius(0)
   {}
   Eigen::Vector3d tip;
 
@@ -139,12 +148,13 @@ struct RAYLIB_EXPORT BranchSection
   int root;
   int id;  // 0 based per tree
   double max_distance_to_end;
-  double total_taper; // a weighted taper estimate
-  double total_weight; // the weighting
+  double total_taper;   // a weighted taper estimate
+  double total_weight;  // the weighting
   double len, accuracy, junction_weight;
   double radius_scale;
   int split_count;
   double tree_height;
+  double radius;
   std::vector<int> roots;  // root points
   std::vector<int> ends;
   std::vector<int> children;

--- a/raylib/raylaz.cpp
+++ b/raylib/raylaz.cpp
@@ -8,6 +8,7 @@
 #include "raylib/rayprogressthread.h"
 #include "rayunused.h"
 
+
 #if RAYLIB_WITH_LAS
 #include <liblas/factory.hpp>
 #include <liblas/point.hpp>
@@ -23,16 +24,24 @@ bool readLas(const std::string &file_name,
 {
 #if RAYLIB_WITH_LAS
   std::cout << "readLas: filename: " << file_name << std::endl;
+  std::ifstream file(file_name);
+
+  if (file)
+  {
+    std::cout << "File exists!" << std::endl;
+  }
+  else
+  {
+    std::cout << "File does not exist." << std::endl;
+  }
 
   std::ifstream ifs;
   ifs.open(file_name.c_str(), std::ios::in | std::ios::binary);
-
   if (ifs.fail())
   {
     std::cerr << "readLas: failed to open stream" << std::endl;
     return false;
   }
-
   liblas::ReaderFactory f;
   liblas::Reader reader = f.CreateWithStream(ifs);
   liblas::Header const &header = reader.GetHeader();
@@ -45,7 +54,6 @@ bool readLas(const std::string &file_name,
   }
 
   const size_t number_of_points = header.GetPointRecordsCount();
-
   bool using_time = (header.GetDataFormatId() & 1) > 0;
   bool using_colour = (header.GetDataFormatId() & 2) > 0;
   if (!using_time)
@@ -144,12 +152,11 @@ bool readLas(std::string file_name, std::vector<Eigen::Vector3d> &positions, std
 {
   std::vector<Eigen::Vector3d> starts;  // dummy as lax just reads in point clouds, not ray clouds
   auto apply = [&](std::vector<Eigen::Vector3d> &start_points, std::vector<Eigen::Vector3d> &end_points,
-                   std::vector<double> &time_points, std::vector<RGBA> &colour_values) 
-  {
+                   std::vector<double> &time_points, std::vector<RGBA> &colour_values) {
     starts.insert(starts.end(), start_points.begin(), start_points.end());
     positions.insert(positions.end(), end_points.begin(), end_points.end());
     times.insert(times.end(), time_points.begin(), time_points.end());
-    colours.insert(colours.end(), colour_values.begin(), colour_values.end());    
+    colours.insert(colours.end(), colour_values.begin(), colour_values.end());
   };
   size_t num_bounded;
   bool success =

--- a/raylib/rayparse.cpp
+++ b/raylib/rayparse.cpp
@@ -80,8 +80,8 @@ bool FileArgument::parse(int argc, char *argv[], int &index, bool set_value)
   std::string file = std::string(argv[index]);
   if (file.length() < 1)
     return false;
-  if (file[0] == '-') // no file should start with a dash. That is reserved for flag arguments
-    return false; 
+  if (file[0] == '-')  // no file should start with a dash. That is reserved for flag arguments
+    return false;
   if (check_extension_)
   {
     if (file.length() <= 2)
@@ -240,7 +240,7 @@ bool Vector3dArgument::parse(int argc, char *argv[], int &index, bool set_value)
       if (val < min_value_ || val > max_value_)
       {
         std::cout << "Please set argument " << index << " within the range: " << min_value_ << " to " << max_value_
-                  << std::endl;
+                  << " provided " << val << std::endl;
         return false;
       }
       value_[i] = val;
@@ -409,6 +409,30 @@ bool OptionalKeyValueArgument::parse(int argc, char *argv[], int &index, bool se
     }
     return true;
   }
+  return false;
+}
+
+bool Optional3DVectorArgument::parse(int argc, char *argv[], int &index, bool set_value)
+{
+  if (index >= argc)
+    return false;
+
+  std::string str(argv[index]);
+  if (str == ("--" + name_))
+  {
+    if (set_value)
+      is_set_ = true;
+
+    index++;
+    if (!value_->parse(argc, argv, index, set_value))
+    {
+      index--;
+      return false;
+    }
+
+    return true;
+  }
+
   return false;
 }
 

--- a/raylib/rayparse.h
+++ b/raylib/rayparse.h
@@ -145,8 +145,8 @@ class RAYLIB_EXPORT Vector2dArgument : public ValueArgument
 {
 public:
   Vector2dArgument();
-  Vector2dArgument(double min_element_value, double max_element_value, 
-    const Eigen::Vector2d &default_value = Eigen::Vector2d(0,0))
+  Vector2dArgument(double min_element_value, double max_element_value,
+                   const Eigen::Vector2d &default_value = Eigen::Vector2d(0, 0))
     : min_value_(min_element_value)
     , max_value_(max_element_value)
     , value_(default_value)
@@ -164,8 +164,8 @@ class RAYLIB_EXPORT Vector3dArgument : public ValueArgument
 {
 public:
   Vector3dArgument();
-  Vector3dArgument(double min_element_value, double max_element_value, 
-    const Eigen::Vector3d &default_value = Eigen::Vector3d(0,0,0))
+  Vector3dArgument(double min_element_value, double max_element_value,
+                   const Eigen::Vector3d &default_value = Eigen::Vector3d(0, 0, 0))
     : min_value_(min_element_value)
     , max_value_(max_element_value)
     , value_(default_value)
@@ -184,7 +184,7 @@ class RAYLIB_EXPORT Vector4dArgument : public ValueArgument
 public:
   Vector4dArgument();
   Vector4dArgument(double min_element_value, double max_element_value,
-    const Eigen::Vector4d &default_value = Eigen::Vector4d(0,0,0,0))
+                   const Eigen::Vector4d &default_value = Eigen::Vector4d(0, 0, 0, 0))
     : min_value_(min_element_value)
     , max_value_(max_element_value)
     , value_(default_value)
@@ -202,7 +202,8 @@ class RAYLIB_EXPORT FileArgumentList : public FixedArgument
 {
 public:
   FileArgumentList(int min_number, bool check_extension = true)
-    : min_number_(min_number), check_extension_(check_extension)
+    : min_number_(min_number)
+    , check_extension_(check_extension)
   {}
   virtual bool parse(int argc, char *argv[], int &index, bool set_value);
   inline const std::vector<FileArgument> &files() const { return files_; }
@@ -319,6 +320,26 @@ private:
   std::string name_;
   char character_;
   FixedArgument *value_;
+  bool is_set_;
+};
+
+/// Optional 3d vector, e.g. "--offset 0,0,0"
+struct RAYLIB_EXPORT Optional3DVectorArgument : OptionalArgument
+{
+public:
+  Optional3DVectorArgument();
+  Optional3DVectorArgument(const std::string &name, Vector3dArgument *value)
+    : name_(name)
+    , value_(value)
+    , is_set_(false)
+  {}
+  virtual bool parse(int argc, char *argv[], int &index, bool set_value);
+  inline const std::string &name() const { return name_; }
+  inline bool isSet() const { return is_set_; }
+
+private:
+  std::string name_;
+  Vector3dArgument *value_;
   bool is_set_;
 };
 


### PR DESCRIPTION
A couple of small changes:

1. Formatted the code using the clang-format in the repo. However, I see quite a few changes, would be happy to be questioned if I did indeed formatted it the right way.
2. Added optional parameter which is interest zone bottom left corner which works with grid_width argument. If user chooses to crop the results using the grid_width parameter, they can choose a point from which this section should be cropped. Default option is taking the middle section, but with interest zone left bottom corner one can crop anywhere.
3. Added option to filter min_radius trees from the results, which is useful if one wants trees only with dbh > 10cm. 

