### PR TITLE
Note prior-driven bias in rayextract trees output

### DIFF
--- a/raycloudtools/rayextract/rayextract.cpp
+++ b/raycloudtools/rayextract/rayextract.cpp
@@ -63,6 +63,8 @@ void usage(int exit_code = 1)
     std::cout << "                            --grid_width 10      - (-w) crops results assuming cloud has been gridded with given width" << std::endl;
     std::cout << "                            --use_rays           - (-u) use rays to reduce trunk radius overestimation in noisy cloud data" << std::endl;
     std::cout << "                            (for internal constants -c -g -s see source file rayextract)" << std::endl;
+    std::cout << "   note: branch radii rely on priors (Leonardo's rule at splits, self-similar taper) that can bias branch" << std::endl;
+    std::cout << "         measurements. Only use these results if the mechanism and its implications are understood." << std::endl;
   // These are the internal parameters that I don't expose as they are 'advanced' only, you shouldn't need to adjust them
   //  std::cout << "                            --cylinder_length_to_width 4- (-c) how slender the cylinders are" << std::endl;
   //  std::cout << "                            --gap_ratio 0.016    - (-g) will split for lateral gaps at this multiple of branch length" << std::endl;

--- a/raycloudtools/rayextract/rayextract.cpp
+++ b/raycloudtools/rayextract/rayextract.cpp
@@ -252,6 +252,8 @@ int rayExtract(int argc, char *argv[])
     forest.generateSmoothMesh(tree_mesh, -1, 1, 1, 1);
     output_file = cloud_file.nameStub() + "_trees_mesh.ply";
     ray::writePlyMesh(output_file, tree_mesh, true);    
+    std::cout << "note: branch radii rely on priors (Leonardo's rule at splits, self-similar taper) that can bias branch" << std::endl;
+    std::cout << "      measurements. Only use these results if the mechanism and its implications are understood." << std::endl;
   }
   // extract the tree locations from a larger, aerial view of a forest
   else if (extract_forest)


### PR DESCRIPTION
Adds a short note to `rayextract trees`, both in its help text and at the end of a run to remind users of the branch segment measurement priors.